### PR TITLE
changing the i18l namespace in a few places.

### DIFF
--- a/lib/vagrant-unison/config.rb
+++ b/lib/vagrant-unison/config.rb
@@ -49,8 +49,8 @@ module VagrantPlugins
       def validate(machine)
         errors = []
 
-        errors << I18n.t("vagrant_sync.config.host_folder_required") if @host_folder.nil?
-        errors << I18n.t("vagrant_sync.config.guest_folder_required") if @guest_folder.nil?
+        errors << I18n.t("vagrant_unison.config.host_folder_required") if @host_folder.nil?
+        errors << I18n.t("vagrant_unison.config.guest_folder_required") if @guest_folder.nil?
 
         { "Unison" => errors }
       end

--- a/lib/vagrant-unison/plugin.rb
+++ b/lib/vagrant-unison/plugin.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
       name "Unison"
       description <<-DESC
       This plugin syncs files over SSH from a local folder
-      to your Vagrant VM (local or on AWS). 
+      to your Vagrant VM (local or on AWS).
       DESC
 
       config "sync" do
@@ -92,7 +92,7 @@ module VagrantPlugins
         # Set the logging level on all "vagrant" namespaced
         # logs as long as we have a valid level.
         if level
-          logger = Log4r::Logger.new("vagrant_sync")
+          logger = Log4r::Logger.new("vagrant_unison")
           logger.outputters = Log4r::Outputter.stderr
           logger.level = level
           logger = nil


### PR DESCRIPTION
the plugin was using the "vagrant_sync" namespace for errors in translations.

