### PR TITLE
specify hostpath in sync-repeat command args

### DIFF
--- a/lib/vagrant-unison/command.rb
+++ b/lib/vagrant-unison/command.rb
@@ -6,9 +6,9 @@ require 'listen'
 module VagrantPlugins
   module Unison
     class Command < Vagrant.plugin("2", :command)
-      
+
       def execute
-        
+
         with_target_vms do |machine|
           hostpath, guestpath = init_paths machine
 
@@ -20,7 +20,7 @@ module VagrantPlugins
             @env.ui.info "Detected modifications to #{modified.inspect}" unless modified.empty?
             @env.ui.info "Detected new files #{added.inspect}" unless added.empty?
             @env.ui.info "Detected deleted files #{removed.inspect}" unless removed.empty?
-            
+
             trigger_unison_sync machine
           end
 
@@ -106,7 +106,7 @@ module VagrantPlugins
             :stderr => r.stderr
         end
       end
-     
+
     end
     class CommandRepeat < Vagrant.plugin("2", :command)
 

--- a/lib/vagrant-unison/command.rb
+++ b/lib/vagrant-unison/command.rb
@@ -3,28 +3,35 @@ require "vagrant"
 require "thread"
 require 'listen'
 
+require_relative 'unison_paths'
+require_relative 'ssh_command'
+require_relative 'shell_command'
+require_relative 'unison_sync'
+
 module VagrantPlugins
   module Unison
     class Command < Vagrant.plugin("2", :command)
+      include UnisonSync
 
       def execute
-
         with_target_vms do |machine|
-          hostpath, guestpath = init_paths machine
+          paths = UnisonPaths.new(@env, machine)
+          host_path = paths.host
 
-          trigger_unison_sync machine
+          sync(machine, paths)
 
-          @env.ui.info "Watching #{hostpath} for changes..."
+          @env.ui.info "Watching #{host_path} for changes..."
 
-          listener = Listen.to(hostpath) do |modified, added, removed|
+          listener = Listen.to(host_path) do |modified, added, removed|
             @env.ui.info "Detected modifications to #{modified.inspect}" unless modified.empty?
             @env.ui.info "Detected new files #{added.inspect}" unless added.empty?
             @env.ui.info "Detected deleted files #{removed.inspect}" unless removed.empty?
 
-            trigger_unison_sync machine
+            sync(machine, paths)
           end
 
           queue = Queue.new
+
           callback = lambda do
             # This needs to execute in another thread because Thread
             # synchronization can't happen in a trap context.
@@ -40,225 +47,96 @@ module VagrantPlugins
           end
         end
 
-        0  #all is well
+        0
       end
 
-      def init_paths(machine)
-          hostpath  = File.expand_path(machine.config.sync.host_folder, @env.root_path)
-          guestpath = machine.config.sync.guest_folder
+      def sync(machine, paths)
+        execute_sync_command(machine) do |command|
+          command.batch = true
 
-          # Make sure there is a trailing slash on the host path to
-          # avoid creating an additional directory with rsync
-          hostpath = "#{hostpath}/" if hostpath !~ /\/$/
+          @env.ui.info "Running #{command.to_s}"
 
-          [hostpath, guestpath]
-      end
+          r = Vagrant::Util::Subprocess.execute(*command.to_a)
 
-      def trigger_unison_sync(machine)
-        hostpath, guestpath = init_paths machine
-
-        @env.ui.info "Unisoning changes from {host}::#{hostpath} --> {guest VM}::#{guestpath}"
-
-        ssh_info = machine.ssh_info
-
-        # Create the guest path
-        machine.communicate.sudo("mkdir -p '#{guestpath}'")
-        machine.communicate.sudo("chown #{ssh_info[:username]} '#{guestpath}'")
-
-        proxy_command = ""
-        if ssh_info[:proxy_command]
-          proxy_command = "-o ProxyCommand='#{ssh_info[:proxy_command]}' "
-        end
-
-        rsh = [
-          "-p #{ssh_info[:port]} " +
-          proxy_command +
-          "-o StrictHostKeyChecking=no " +
-          "-o UserKnownHostsFile=/dev/null",
-          ssh_info[:private_key_path].map { |p| "-i #{p}" },
-        ].flatten.join(" ")
-
-        # Unison over to the guest path using the SSH info
-        ignore = machine.config.sync.ignore ? '-ignore "'+machine.config.sync.ignore+'" ' : '';
-        command = [
-          "unison", "-batch",
-          "-sshargs", rsh,
-          hostpath,
-          "ssh://#{ssh_info[:username]}@#{ssh_info[:host]}/#{guestpath}"
-         ]
-        if machine.config.sync.ignore
-          command []= ignore
-        end
-
-        r = Vagrant::Util::Subprocess.execute(*command)
-        case r.exit_code
-        when 0
-          @env.ui.info "Unison completed succesfully"
-        when 1
-          @env.ui.info "Unison completed - all file transfers were successful; some files were skipped"
-        when 2
-          @env.ui.info "Unison completed - non-fatal failures during file transfer"
-        else
-          raise Vagrant::Errors::UnisonError,
-            :command => command.inspect,
-            :guestpath => guestpath,
-            :hostpath => hostpath,
-            :stderr => r.stderr
+          case r.exit_code
+          when 0
+            @env.ui.info "Unison completed succesfully"
+          when 1
+            @env.ui.info "Unison completed - all file transfers were successful; some files were skipped"
+          when 2
+            @env.ui.info "Unison completed - non-fatal failures during file transfer: #{r.stderr}"
+          else
+            raise Vagrant::Errors::UnisonError,
+              :command => command.to_s,
+              :guestpath => paths.guest,
+              :hostpath => paths.host,
+              :stderr => r.stderr
+          end
         end
       end
-
     end
+
     class CommandRepeat < Vagrant.plugin("2", :command)
+      include UnisonSync
 
       def execute
-
         with_target_vms do |machine|
-          hostpath, guestpath = init_paths machine
+          execute_sync_command(machine) do |command|
+            command.repeat = true
+            command.terse = true
+            command = command.to_s
 
-          trigger_unison_sync machine
+            @env.ui.info "Running #{command}"
 
+            system(command)
+          end
         end
 
-        0  #all is well
+        0
       end
-
-      def init_paths(machine)
-          hostpath  = File.expand_path(machine.config.sync.host_folder, @env.root_path)
-          guestpath = machine.config.sync.guest_folder
-
-          # Make sure there is a trailing slash on the host path to
-          # avoid creating an additional directory with rsync
-          hostpath = "#{hostpath}/" if hostpath !~ /\/$/
-
-          [hostpath, guestpath]
-      end
-
-      def trigger_unison_sync(machine)
-        hostpath, guestpath = init_paths machine
-
-        @env.ui.info "Unisoning changes from {host}::#{hostpath} --> {guest VM}::#{guestpath}"
-
-        ssh_info = machine.ssh_info
-
-        # Create the guest path
-        machine.communicate.sudo("mkdir -p '#{guestpath}'")
-        machine.communicate.sudo("chown #{ssh_info[:username]} '#{guestpath}'")
-
-        proxy_command = ""
-        if ssh_info[:proxy_command]
-          proxy_command = "-o ProxyCommand='#{ssh_info[:proxy_command]}' "
-        end
-
-        rsh = [
-          "-p #{ssh_info[:port]} " +
-          proxy_command +
-          "-o StrictHostKeyChecking=no " +
-          "-o UserKnownHostsFile=/dev/null",
-          ssh_info[:private_key_path].map { |p| "-i #{p}" },
-        ].flatten.join(" ")
-
-        # Unison over to the guest path using the SSH info
-        ignore = machine.config.sync.ignore ? ' -ignore "'+machine.config.sync.ignore+'"' : '';
-        command = 'unison -terse -repeat 1 -sshargs "'+rsh+'" hosts '+"ssh://#{ssh_info[:username]}@#{ssh_info[:host]}/#{guestpath}"+ignore
-        @env.ui.info "Running #{command}"
-
-        system(command)
-      end
-
     end
+
     class CommandCleanup < Vagrant.plugin("2", :command)
+      include UnisonSync
 
       def execute
-
         with_target_vms do |machine|
-          hostpath, guestpath = init_paths machine
+          guest_path = UnisonPaths.new(@env, machine).guest
 
-          trigger_unison_sync machine
+          command = "rm -rf ~/Library/'Application Support'/Unison/*"
+          @env.ui.info "Running #{command} on host"
+          system(command)
 
+          command = "rm -rf #{guest_path}"
+          @env.ui.info "Running #{command} on guest VM"
+          machine.communicate.sudo(command)
+
+          command = "rm -rf ~/.unison"
+          @env.ui.info "Running #{command} on guest VM"
+          machine.communicate.sudo(command)
         end
 
-        0  #all is well
+        0
       end
-
-      def init_paths(machine)
-          hostpath  = File.expand_path(machine.config.sync.host_folder, @env.root_path)
-          guestpath = machine.config.sync.guest_folder
-
-          # Make sure there is a trailing slash on the host path to
-          # avoid creating an additional directory with rsync
-          hostpath = "#{hostpath}/" if hostpath !~ /\/$/
-
-          [hostpath, guestpath]
-      end
-
-      def trigger_unison_sync(machine)
-        hostpath, guestpath = init_paths machine
-
-        # Unison over to the guest path using the SSH info
-        command = "rm -rf ~/Library/'Application Support'/Unison/* ; rm -rf #{guestpath}/*"
-        @env.ui.info "Running #{command}"
-
-        system(command)
-      end
-
     end
+
     class CommandInteract < Vagrant.plugin("2", :command)
+      include UnisonSync
 
       def execute
-
         with_target_vms do |machine|
-          hostpath, guestpath = init_paths machine
+          execute_sync_command(machine) do |command|
+            command.terse = true
+            command = command.to_s
 
-          trigger_unison_sync machine
+            @env.ui.info "Running #{command}"
 
+            system(command)
+          end
         end
 
-        0  #all is well
+        0
       end
-
-      def init_paths(machine)
-          hostpath  = File.expand_path(machine.config.sync.host_folder, @env.root_path)
-          guestpath = machine.config.sync.guest_folder
-
-          # Make sure there is a trailing slash on the host path to
-          # avoid creating an additional directory with rsync
-          hostpath = "#{hostpath}/" if hostpath !~ /\/$/
-
-          [hostpath, guestpath]
-      end
-
-      def trigger_unison_sync(machine)
-        hostpath, guestpath = init_paths machine
-
-        @env.ui.info "Unisoning changes from {host}::#{hostpath} --> {guest VM}::#{guestpath}"
-
-        ssh_info = machine.ssh_info
-
-        # Create the guest path
-        machine.communicate.sudo("mkdir -p '#{guestpath}'")
-        machine.communicate.sudo("chown #{ssh_info[:username]} '#{guestpath}'")
-
-        proxy_command = ""
-        if ssh_info[:proxy_command]
-          proxy_command = "-o ProxyCommand='#{ssh_info[:proxy_command]}' "
-        end
-
-        rsh = [
-          "-p #{ssh_info[:port]} " +
-          proxy_command +
-          "-o StrictHostKeyChecking=no " +
-          "-o UserKnownHostsFile=/dev/null",
-          ssh_info[:private_key_path].map { |p| "-i #{p}" },
-        ].flatten.join(" ")
-
-        # Unison over to the guest path using the SSH info
-        ignore = machine.config.sync.ignore ? ' -ignore "'+machine.config.sync.ignore+'"' : '';
-        command = 'unison -terse -sshargs "'+rsh+'" hosts '+"ssh://#{ssh_info[:username]}@#{ssh_info[:host]}/#{guestpath}"+ignore
-        @env.ui.info "Running #{command}"
-
-        system(command)
-      end
-
     end
   end
 end

--- a/lib/vagrant-unison/config.rb
+++ b/lib/vagrant-unison/config.rb
@@ -18,10 +18,16 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :ignore
 
+      # Repeat speed.
+      #
+      # @return [String]
+      attr_accessor :repeat
+
       def initialize(region_specific=false)
         @host_folder      = UNSET_VALUE
         @remote_folder    = UNSET_VALUE
         @ignore           = UNSET_VALUE
+        @repeat           = UNSET_VALUE
       end
 
       #-------------------------------------------------------------------
@@ -41,6 +47,7 @@ module VagrantPlugins
         @host_folder    = nil if @host_folder    == UNSET_VALUE
         @guest_folder   = nil if @guest_folder   == UNSET_VALUE
         @ignore         = nil if @ignore         == UNSET_VALUE
+        @repeat         = 1   if @repeat         == UNSET_VALUE
 
         # Mark that we finalized
         @__finalized = true

--- a/lib/vagrant-unison/shell_command.rb
+++ b/lib/vagrant-unison/shell_command.rb
@@ -1,0 +1,55 @@
+module VagrantPlugins
+  module Unison
+    class ShellCommand
+      def initialize machine, paths, ssh_command
+        @machine = machine
+        @paths = paths
+        @ssh_command = ssh_command
+      end
+
+      attr_accessor :batch, :repeat, :terse
+
+      def to_a
+        args.map do |arg|
+          arg = arg[1...-1] if arg =~ /\A"(.*)"\z/
+          arg
+        end
+      end
+
+      def to_s
+        args.join(' ')
+      end
+
+      private
+
+      def args
+        [
+          'unison',
+          @paths.host,
+          @ssh_command.uri,
+          batch_arg,
+          terse_arg,
+          repeat_arg,
+          ignore_arg,
+          ['-sshargs', %("#{@ssh_command.command}")],
+        ].flatten.compact
+      end
+
+      def batch_arg
+        '-batch' if batch
+      end
+
+      def ignore_arg
+        ['-ignore', %("#{@machine.config.sync.ignore}")] if @machine.config.sync.ignore
+      end
+
+      def repeat_arg
+        ['-repeat', @machine.config.sync.repeat] if repeat && @machine.config.sync.repeat
+      end
+
+      def terse_arg
+        '-terse' if terse
+      end
+    end
+  end
+end

--- a/lib/vagrant-unison/ssh_command.rb
+++ b/lib/vagrant-unison/ssh_command.rb
@@ -1,0 +1,43 @@
+module VagrantPlugins
+  module Unison
+    class SshCommand
+      def initialize(machine, unison_paths)
+        @machine = machine
+        @unison_paths = unison_paths
+      end
+
+      def command
+        %W(
+          -p #{ssh_info[:port]}
+          #{proxy_command}
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
+          #{key_paths}
+        ).compact.join(' ')
+      end
+
+      def uri
+        username = ssh_info[:username]
+        host = ssh_info[:host]
+
+        "ssh://#{username}@#{host}/#{@unison_paths.guest}"
+      end
+
+      private
+
+      def proxy_command
+        command = ssh_info[:proxy_command]
+        return nil unless command
+        "-o ProxyCommand='#{command}'"
+      end
+
+      def ssh_info
+        @machine.ssh_info
+      end
+
+      def key_paths
+        ssh_info[:private_key_path].map { |p| "-i #{p}" }.join(' ')
+      end
+    end
+  end
+end

--- a/lib/vagrant-unison/unison_paths.rb
+++ b/lib/vagrant-unison/unison_paths.rb
@@ -1,0 +1,24 @@
+module VagrantPlugins
+  module Unison
+    class UnisonPaths
+      def initialize(env, machine)
+        @env = env
+        @machine = machine
+      end
+
+      def guest
+        @machine.config.sync.guest_folder
+      end
+
+      def host
+        @host ||= begin
+          path = File.expand_path(@machine.config.sync.host_folder, @env.root_path)
+
+          # Make sure there is a trailing slash on the host path to
+          # avoid creating an additional directory with rsync
+          path = "#{path}/" if path !~ /\/$/
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-unison/unison_sync.rb
+++ b/lib/vagrant-unison/unison_sync.rb
@@ -1,0 +1,22 @@
+module VagrantPlugins
+  module Unison
+    module UnisonSync
+      def execute_sync_command(machine)
+        unison_paths = UnisonPaths.new(@env, machine)
+        guest_path = unison_paths.guest
+        host_path = unison_paths.host
+
+        @env.ui.info "Unisoning changes from {host}::#{host_path} --> {guest VM}::#{guest_path}"
+
+        # Create the guest path
+        machine.communicate.sudo("mkdir -p '#{guest_path}'")
+        machine.communicate.sudo("chown #{machine.ssh_info[:username]} '#{guest_path}'")
+
+        ssh_command = SshCommand.new(machine, unison_paths)
+        shell_command = ShellCommand.new(machine, unison_paths, ssh_command)
+
+        yield shell_command
+      end
+    end
+  end
+end

--- a/lib/vagrant-unison/version.rb
+++ b/lib/vagrant-unison/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Unison
-    VERSION = "0.0.15"
+    VERSION = "0.0.16"
   end
 end


### PR DESCRIPTION
hey there.

```sync-repeat``` was not working for me, and I tracked it down to the unison command args. I don't know if ```hosts``` has a special meaning in unison, but in my testing it just treated it as a local path and synced everything from the remote host into a local ```./hosts``` directory that it created. If I change it to the host path from my Vagrantfile config, everything works as expected.